### PR TITLE
feat: Swagger 설정 및 UserController 문서화 (closes #37)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cotato/workbook/domain/user/controller/UserController.java
+++ b/src/main/java/com/cotato/workbook/domain/user/controller/UserController.java
@@ -1,0 +1,38 @@
+package com.cotato.workbook.domain.user.controller;
+
+import com.cotato.workbook.domain.user.dto.UserRequest;
+import com.cotato.workbook.domain.user.dto.UserResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "User API", description = "유저 관련 API")
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    @Operation(summary = "유저 단건 조회", description = "ID로 유저 정보를 조회해요.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음")
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<UserResponse> getUser(
+        @Parameter(description = "조회할 유저의 ID", example = "1")
+        @PathVariable Long id) {
+        // 실제로는 Service를 통해 DB에서 유저를 조회해요
+        // 지금은 더미 데이터를 직접 반환할게요
+        return ResponseEntity.ok(new UserResponse(id, "임준서", "junseo@example.com"));
+    }
+
+    @Operation(summary = "유저 생성", description = "새로운 유저를 생성해요.")
+    @ApiResponse(responseCode = "200", description = "생성 성공")
+    @PostMapping
+    public ResponseEntity<UserResponse> createUser(@RequestBody UserRequest request) {
+        return ResponseEntity.ok(new UserResponse(1L, request.getName(), request.getEmail()));
+    }
+}

--- a/src/main/java/com/cotato/workbook/domain/user/dto/UserRequest.java
+++ b/src/main/java/com/cotato/workbook/domain/user/dto/UserRequest.java
@@ -1,0 +1,9 @@
+package com.cotato.workbook.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserRequest {
+    private String name;
+    private String email;
+}

--- a/src/main/java/com/cotato/workbook/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/cotato/workbook/domain/user/dto/UserResponse.java
@@ -1,0 +1,12 @@
+package com.cotato.workbook.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserResponse {
+    private Long id;
+    private String name;
+    private String email;
+}

--- a/src/main/java/com/cotato/workbook/global/config/SwaggerConfig.java
+++ b/src/main/java/com/cotato/workbook/global/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.cotato.workbook.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("My API")                    // 문서 제목
+                .description("스터디 실습용 API 문서")  // 설명
+                .version("v1.0.0"));                  // 버전
+    }
+}


### PR DESCRIPTION
## 개요
Swagger(SpringDoc OpenAPI 3)를 프로젝트에 추가하고 UserController API를 문서화했습니다.

## 작업 내용
- SpringDoc 의존성 추가
- SwaggerConfig 설정
- UserController 작성 (GET /users/{id}, POST /users)
- Swagger 어노테이션 적용 (@Tag, @Operation, @Parameter, @ApiResponse)

## 관련 이슈
closes #37

## 리뷰 포인트
- Swagger 어노테이션이 올바르게 적용됐는지 확인해 주세요
 