### PR TITLE
feat: [윤해민] 공통 응답 포맷 및 에러 핸들링 구현 (closes #64)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// Swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 
 	// Lombok — 반복적인 코드(Getter, Setter, 생성자 등)를 어노테이션으로 자동 생성해줘요
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/cotato/workbook/domain/user/controller/UserController.java
+++ b/src/main/java/com/cotato/workbook/domain/user/controller/UserController.java
@@ -2,6 +2,10 @@ package com.cotato.workbook.domain.user.controller;
 
 import com.cotato.workbook.domain.user.dto.UserRequest;
 import com.cotato.workbook.domain.user.dto.UserResponse;
+import com.cotato.workbook.domain.user.exception.UserException;
+import com.cotato.workbook.domain.user.exception.code.UserErrorCode;
+import com.cotato.workbook.domain.user.exception.code.UserSuccessCode;
+import com.cotato.workbook.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -17,24 +21,29 @@ public class UserController {
 
     @Operation(summary = "유저 단건 조회", description = "ID로 유저 정보를 조회해요.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음") // 가능한 응답 코드를 문서화해요
+        @ApiResponse(responseCode = "USER2001", description = "조회 성공"),
+        @ApiResponse(responseCode = "USER4041", description = "유저를 찾을 수 없음") // 가능한 응답 코드를 문서화해요
     })
     @GetMapping("/{id}")  // GET /users/{id} 요청을 처리해요
-    public ResponseEntity<UserResponse> getUser(
-            @Parameter(description = "조회할 유저의 ID", example = "1") // Swagger UI에 파라미터 설명과 예시값이 표시돼요
-            @PathVariable Long id) {
+    public CommonResponse<UserResponse> getUser(
+        @Parameter(description = "조회할 유저의 ID", example = "1") // Swagger UI에 파라미터 설명과 예시값이 표시돼요
+        @PathVariable Long id) {
         // 실제로는 Service를 통해 DB에서 유저를 조회해요
         // 지금은 더미 데이터를 직접 반환할게요
-        return ResponseEntity.ok(new UserResponse(id, "임준서", "junseo@example.com"));
+        if (id == 999L) {
+            throw new UserException(UserErrorCode.USER_NOT_FOUND);
+        }
+        return CommonResponse.onSuccess(UserSuccessCode.USER_FOUND,
+            new UserResponse(id, "임준서", "junseo@example.com"));
     }
 
     @Operation(summary = "유저 생성", description = "새로운 유저를 생성해요.")
-    @ApiResponse(responseCode = "200", description = "생성 성공")
+    @ApiResponse(responseCode = "USER2011", description = "생성 성공")
     @PostMapping           // POST /users 요청을 처리해요
-    public ResponseEntity<UserResponse> createUser(@RequestBody UserRequest request) {
+    public CommonResponse<UserResponse> createUser(@RequestBody UserRequest request) {
         // @RequestBody: HTTP 요청 body의 JSON을 UserRequest 객체로 변환해줘요
         // 실제로는 Service를 통해 DB에 저장해요
-        return ResponseEntity.ok(new UserResponse(1L, request.getName(), request.getEmail()));
+        return CommonResponse.onSuccess(UserSuccessCode.USER_CREATED,
+            new UserResponse(1L, request.getName(), request.getEmail()));
     }
 }

--- a/src/main/java/com/cotato/workbook/domain/user/exception/UserException.java
+++ b/src/main/java/com/cotato/workbook/domain/user/exception/UserException.java
@@ -1,0 +1,12 @@
+package com.cotato.workbook.domain.user.exception;
+
+import com.cotato.workbook.domain.user.exception.code.UserErrorCode;
+import com.cotato.workbook.global.exception.CustomException;
+
+// UserException.java
+public class UserException extends CustomException {
+
+  public UserException(UserErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/com/cotato/workbook/domain/user/exception/code/UserErrorCode.java
+++ b/src/main/java/com/cotato/workbook/domain/user/exception/code/UserErrorCode.java
@@ -1,0 +1,20 @@
+package com.cotato.workbook.domain.user.exception.code;
+
+import com.cotato.workbook.global.exception.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+// UserErrorCode.java
+@Getter
+@AllArgsConstructor
+public enum UserErrorCode implements BaseErrorCode {
+
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4041", "존재하지 않는 유저입니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+  // @Getter가 getHttpStatus(), getCode(), getMessage()를 자동으로 만들어줘서
+  // BaseErrorCode 인터페이스의 메서드를 별도 구현 없이 바로 충족해요
+}

--- a/src/main/java/com/cotato/workbook/domain/user/exception/code/UserSuccessCode.java
+++ b/src/main/java/com/cotato/workbook/domain/user/exception/code/UserSuccessCode.java
@@ -1,0 +1,21 @@
+package com.cotato.workbook.domain.user.exception.code;
+
+import com.cotato.workbook.global.exception.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+// UserSuccessCode.java
+@Getter
+@AllArgsConstructor
+public enum UserSuccessCode implements BaseSuccessCode {
+
+  USER_FOUND(HttpStatus.OK, "USER2001", "유저를 조회했습니다."),
+  USER_CREATED(HttpStatus.CREATED, "USER2011", "유저가 생성되었습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+  // @Getter가 getHttpStatus(), getCode(), getMessage()를 자동으로 만들어줘서
+  // BaseSuccessCode 인터페이스의 메서드를 별도 구현 없이 바로 충족해요
+}

--- a/src/main/java/com/cotato/workbook/global/exception/CustomException.java
+++ b/src/main/java/com/cotato/workbook/global/exception/CustomException.java
@@ -1,0 +1,16 @@
+package com.cotato.workbook.global.exception;
+
+import com.cotato.workbook.global.exception.code.BaseErrorCode;
+import lombok.Getter;
+
+// CustomException.java
+@Getter
+public class CustomException extends RuntimeException {
+
+  private final BaseErrorCode errorCode;
+
+  public CustomException(BaseErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/com/cotato/workbook/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cotato/workbook/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.cotato.workbook.global.exception;
+
+import com.cotato.workbook.global.exception.code.BaseErrorCode;
+import com.cotato.workbook.global.response.CommonResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+// GlobalExceptionHandler.java
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  // CustomException 처리 — UserException, PostException 등 모두 여기서 처리돼요
+  @ExceptionHandler(CustomException.class)
+  public ResponseEntity<CommonResponse<Void>> handleCustomException(CustomException e) {
+    BaseErrorCode errorCode = e.getErrorCode();
+    return ResponseEntity
+        .status(errorCode.getHttpStatus())
+        .body(CommonResponse.onFailure(errorCode.getCode(), errorCode.getMessage()));
+  }
+
+  // 그 외 예상치 못한 예외 처리
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<CommonResponse<Void>> handleException(Exception e) {
+    return ResponseEntity
+        .status(500)
+        .body(CommonResponse.onFailure("COMMON5001", "서버 에러가 발생했습니다."));
+  }
+}

--- a/src/main/java/com/cotato/workbook/global/exception/code/BaseErrorCode.java
+++ b/src/main/java/com/cotato/workbook/global/exception/code/BaseErrorCode.java
@@ -1,0 +1,10 @@
+package com.cotato.workbook.global.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+// BaseErrorCode.java
+public interface BaseErrorCode {
+  HttpStatus getHttpStatus();
+  String getCode();
+  String getMessage();
+}

--- a/src/main/java/com/cotato/workbook/global/exception/code/BaseSuccessCode.java
+++ b/src/main/java/com/cotato/workbook/global/exception/code/BaseSuccessCode.java
@@ -1,0 +1,10 @@
+package com.cotato.workbook.global.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+// BaseSuccessCode.java
+public interface BaseSuccessCode {
+  HttpStatus getHttpStatus();
+  String getCode();
+  String getMessage();
+}

--- a/src/main/java/com/cotato/workbook/global/exception/code/GlobalErrorCode.java
+++ b/src/main/java/com/cotato/workbook/global/exception/code/GlobalErrorCode.java
@@ -1,0 +1,20 @@
+package com.cotato.workbook.global.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+// GlobalErrorCode.java
+@Getter
+@AllArgsConstructor
+public enum GlobalErrorCode implements BaseErrorCode {
+
+  COMMON_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON5001", "서버 에러가 발생했습니다."),
+  COMMON_BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON4001", "잘못된 요청입니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+  // @Getter가 getHttpStatus(), getCode(), getMessage()를 자동으로 만들어줘서
+  // BaseErrorCode 인터페이스의 메서드를 별도 구현 없이 바로 충족해요
+}

--- a/src/main/java/com/cotato/workbook/global/exception/code/GlobalSuccessCode.java
+++ b/src/main/java/com/cotato/workbook/global/exception/code/GlobalSuccessCode.java
@@ -1,0 +1,19 @@
+package com.cotato.workbook.global.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+// GlobalSuccessCode.java
+@Getter
+@AllArgsConstructor
+public enum GlobalSuccessCode implements BaseSuccessCode {
+
+  COMMON_OK(HttpStatus.OK, "COMMON2001", "요청에 성공했습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+  // @Getter가 getHttpStatus(), getCode(), getMessage()를 자동으로 만들어줘서
+  // BaseSuccessCode 인터페이스의 메서드를 별도 구현 없이 바로 충족해요
+}

--- a/src/main/java/com/cotato/workbook/global/response/CommonResponse.java
+++ b/src/main/java/com/cotato/workbook/global/response/CommonResponse.java
@@ -1,0 +1,32 @@
+package com.cotato.workbook.global.response;
+
+import com.cotato.workbook.global.exception.code.BaseSuccessCode;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// CommonResponse.java
+// 예외와 관계없이 모든 API 응답을 래핑하는 클래스
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"}) // JSON 응답 필드 출력 순서를 고정해요
+public class CommonResponse<T> {
+
+  private final Boolean isSuccess;
+  private final String code;
+  private final String message;
+  private T result;
+
+  // 성공 응답 — BaseSuccessCode를 구현한 Enum이라면 모두 받을 수 있어요
+  public static <T> CommonResponse<T> onSuccess(BaseSuccessCode successCode, T result) {
+    return new CommonResponse<>(true,
+        successCode.getCode(),
+        successCode.getMessage(),
+        result);
+  }
+
+  // 실패 응답
+  public static <T> CommonResponse<T> onFailure(String code, String message) {
+    return new CommonResponse<>(false, code, message, null);
+  }
+}


### PR DESCRIPTION
## 개요
공통 응답 포맷(CommonResponse)과 에러 핸들링 구조를 구현했습니다.

## 작업 내용
- CommonResponse 공통 응답 클래스 작성
- BaseSuccessCode / BaseErrorCode 인터페이스 작성 (DTO 없이 메서드 직접 정의)
- GlobalSuccessCode / GlobalErrorCode Enum 정의 (공통 코드)
- UserSuccessCode / UserErrorCode Enum 정의 (유저 도메인 코드)
- CustomException 작성
- UserSuccessCode 작성
- UserException 작성
- GlobalExceptionHandler 작성 (@RestControllerAdvice)
- UserController에 CommonResponse, UserSuccessCode, UserException 적용

## 관련 이슈
closes #64 

## 참고 자료
> 관련 문서, 링크 등이 있으면 추가해주세요.
 📸 스크린샷을 찍어서 PR description에 첨부해 주세요!
<img width="1394" height="938" alt="image" src="https://github.com/user-attachments/assets/2f8e4488-34ba-4eb9-9c76-a216755af7bd" />

<img width="1393" height="905" alt="image" src="https://github.com/user-attachments/assets/c0b3828b-fe87-4c37-8da9-bc63af3c5aba" />

 
## 리뷰 포인트
- 도메인별 에러 코드 분리 구조가 적절한지 확인해 주세요
- CustomException 상속 구조가 올바르게 동작하는지 확인해 주세요